### PR TITLE
Add pub to make_handler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,26 @@ pub struct HookBuilder {
 }
 
 impl HookBuilder {
+    /// Build a [`Handler`] for an error.
+    /// Normally, [`HookBuilder::install()`] will configure the global error
+    /// hook to call this function, but you can use it directly instead if you
+    /// want to customize the error hook.
+    ///
+    /// # Example
+    ///
+    /// ```rust,should_panic
+    /// use stable_eyre::{eyre::{self, eyre, Report}, HookBuilder};
+    ///
+    /// fn main() -> Result<(), Report> {
+    ///     let hook_builder = HookBuilder::default();
+    ///     eyre::set_hook(Box::new(move |error| {
+    ///         // ...do something else with `error`...
+    ///         Box::new(hook_builder.make_handler(error))
+    ///     }));
+    ///
+    ///     Err(eyre!("oh no!"))
+    /// }
+    /// ```
     #[allow(unused_variables)]
     pub fn make_handler(&self, error: &(dyn Error + 'static)) -> Handler {
         let backtrace = if self.capture_enabled() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub struct HookBuilder {
 
 impl HookBuilder {
     #[allow(unused_variables)]
-    fn make_handler(&self, error: &(dyn Error + 'static)) -> Handler {
+    pub fn make_handler(&self, error: &(dyn Error + 'static)) -> Handler {
         let backtrace = if self.capture_enabled() {
             Some(Backtrace::new())
         } else {


### PR DESCRIPTION
I would like to set `stable_eyre`'s hook as my `eyre` hook, but also do something else application-specific alongside it.

Currently, `stable_eyre::install()` just calls `HookBuilder::install()`, which in turn calls `eyre::set_hook()` like this:
https://github.com/eyre-rs/stable-eyre/blob/48f50e37665195a77e8e2dc53fd0bb1201a9a332/src/lib.rs#L168

I'd like to be able to write something like this:
```rust
let hook_builder = stable_eyre::HookBuilder::default();
stable_eyre::eyre::set_hook(Box::new(move |e| {
    do_something_else(e);
    Box::new(hook_builder.make_handler(e))
}))?;
```

However, `HookBuilder::make_handler()` is private, and so I can't construct or wrap `stable-eyre`'s Handler, and `install()` doesn't give any options to run extra code at hook-time.

This PR fixes that.